### PR TITLE
Fix tf2.0 import error

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,8 @@ $ sudo pip3 install keras_applications==1.0.7 --no-deps
 $ sudo pip3 install keras_preprocessing==1.0.9 --no-deps
 $ sudo pip3 install h5py==2.9.0
 $ sudo apt-get install -y openmpi-bin libopenmpi-dev
-$ sudo -H pip3 install -U --user six numpy wheel mock
+$ sudo apt-get install -y libatlas-base-dev
+$ pip3 install -U --user six wheel mock
 $ sudo apt update;sudo apt upgrade
 $ wget https://github.com/PINTO0309/Tensorflow-bin/raw/master/tensorflow-2.0.0b1-cp35-cp35m-linux_armv7l.whl
 $ sudo pip3 uninstall tensorflow


### PR DESCRIPTION
Fixed the installation procedure of Tensorflow v2.

1. Fix installation of six wheel mock modules.
For the `sudo -H` option, the module is installed in `root/.local`. Because of this, numpy (1.12.1 pre-installed) under '/ usr/lib` is loaded first, and an error occurs at import. 
```
ImportError: No module named 'numpy.core._multiarray_umath'
ImportError: numpy.core.multiarray failed to import

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<frozen importlib._bootstrap>", line 968, in _find_and_load
SystemError: PyEval_EvalFrameEx returned a result with an error set
ImportError: numpy.core._multiarray_umath failed to import
ImportError: numpy.core.umath failed to import
2019-06-19 20:42:03.617519: F tensorflow/python/lib/core/bfloat16.cc:675] Check failed: PyBfloat16_Type.tp_base != nullptr
```


2. Add install module `libatlas-base-dev`
libatlas-base-dev is required by numpy (1.16.4).
If not installed, an error will occur.
```
Traceback (most recent call last):
  File "/home/pi/.local/lib/python3.5/site-packages/numpy/core/__init__.py", line 40, in <module>
    from . import multiarray
  File "/home/pi/.local/lib/python3.5/site-packages/numpy/core/multiarray.py", line 12, in <module>
    from . import overrides
  File "/home/pi/.local/lib/python3.5/site-packages/numpy/core/overrides.py", line 6, in <module>
    from numpy.core._multiarray_umath import (
ImportError: libf77blas.so.3: cannot open shared object file: No such file or directory

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib/python3.5/dist-packages/tensorflow/__init__.py", line 28, in <module>
    from tensorflow.python import pywrap_tensorflow  # pylint: disable=unused-import
  File "/usr/local/lib/python3.5/dist-packages/tensorflow/python/__init__.py", line 47, in <module>
    import numpy as np
  File "/home/pi/.local/lib/python3.5/site-packages/numpy/__init__.py", line 142, in <module>
    from . import core
  File "/home/pi/.local/lib/python3.5/site-packages/numpy/core/__init__.py", line 71, in <module>
    raise ImportError(msg)
ImportError: 

IMPORTANT: PLEASE READ THIS FOR ADVICE ON HOW TO SOLVE THIS ISSUE!

Importing the multiarray numpy extension module failed.  Most
likely you are trying to import a failed build of numpy.
Here is how to proceed:
- If you're working with a numpy git repository, try `git clean -xdf`
  (removes all files not under version control) and rebuild numpy.
- If you are simply trying to use the numpy version that you have installed:
  your installation is broken - please reinstall numpy.
- If you have already reinstalled and that did not fix the problem, then:
  1. Check that you are using the Python you expect (you're using /usr/bin/python3),
     and that you have no directories in your PATH or PYTHONPATH that can
     interfere with the Python and numpy versions you're trying to use.
  2. If (1) looks fine, you can open a new issue at
     https://github.com/numpy/numpy/issues.  Please include details on:
     - how you installed Python
     - how you installed numpy
     - your operating system
     - whether or not you have multiple versions of Python installed
     - if you built from source, your compiler versions and ideally a build log

     Note: this error has many possible causes, so please don't comment on
     an existing issue about this - open a new one instead.

Original error was: libf77blas.so.3: cannot open shared object file: No such file or directory
```